### PR TITLE
Feat/fetch combined artworks api

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -1,68 +1,123 @@
-import { fetchArtworksMet, fetchArtworksVA, metApi, vaApi } from "@/api/api";
+import {
+  fetchArtworksMet,
+  fetchArtworksVA,
+  fetchCombinedArtworks,
+  metApi,
+  vaApi,
+} from "@/api/api";
 import axiosMockAdapter from "axios-mock-adapter";
+describe("Search Museum API", () => {
+  const vaMock = new axiosMockAdapter(vaApi);
+  const metMock = new axiosMockAdapter(metApi);
 
-describe("GET: V&A Museum API functions", () => {
-  const mock = new axiosMockAdapter(vaApi);
-
-  afterEach(() => {
-    mock.reset();
-  });
-
-  it("searches V&A artworks successfully with 200 status response", async () => {
-    const mockData = {
-      records: [
-        {
-          systemNumber: "23",
-          _primaryTitle: "Klint painting",
-        },
-      ],
-    };
-    mock.onGet("/search?q=klint&page_size=10").reply(200, mockData);
-
-    const result = await fetchArtworksVA("klint");
-
-    expect(result).toEqual(mockData);
-  });
-  it("handles network errors in V&A search with 500 status response and error message", async () => {
-    mock.onGet("/search?q=klint&page_size=10").reply(500);
-
-    await expect(fetchArtworksVA("klint")).rejects.toThrow(
-      "V&A Museum API request failed"
-    );
-  });
-});
-
-describe("GET: Met Museum API functions", () => {
-  const mock = new axiosMockAdapter(metApi);
-  afterEach(() => mock.reset());
-
-  it("searches Met records successfully with 200 status response", async () => {
-    const mockSearchData = {
-      objectIDs: [2, 5, 9],
-    };
-
-    const mockObjectData = [
-      { objectID: 2, title: "Adulthood" },
-      { objectID: 5, title: "Childhood" },
-      { objectID: 9, title: "Youth" },
-    ];
-    // search endpoint returning objectIDs
-    mock.onGet("/search?q=klint").reply(200, mockSearchData);
-
-    // object endpoint returning object details
-    mockObjectData.forEach((object) => {
-      mock.onGet(`/objects/${object.objectID}`).reply(200, object);
+  describe("GET: V&A Museum API functions", () => {
+    afterEach(() => {
+      vaMock.reset();
     });
+    it("searches V&A artworks successfully with 200 status response", async () => {
+      const mockData = {
+        records: [
+          {
+            systemNumber: "23",
+            _primaryTitle: "Klint painting",
+          },
+        ],
+      };
+      vaMock.onGet("/search?q=klint&page_size=10").reply(200, mockData);
 
-    const result = await fetchArtworksMet("klint");
+      const result = await fetchArtworksVA("klint");
 
-    expect(result).toEqual(mockObjectData);
+      expect(result).toEqual(mockData);
+    });
+    it("handles network errors in V&A search with 500 status response and error message", async () => {
+      vaMock.onGet("/search?q=klint&page_size=10").reply(500);
+
+      await expect(fetchArtworksVA("klint")).rejects.toThrow(
+        "V&A Museum API request failed"
+      );
+    });
   });
-  it("handles network errors in Met search with 500 status response and error message", async () => {
-    mock.onGet("/search?q=klint").reply(500);
+  describe("GET: Met Museum API functions", () => {
+    afterEach(() => metMock.reset());
 
-    await expect(fetchArtworksMet("klint")).rejects.toThrow(
-      "The Met Museum of Art API request failed"
-    );
+    it("searches Met records successfully with 200 status response", async () => {
+      const mockSearchData = {
+        objectIDs: [2, 5, 9],
+      };
+
+      const mockObjectData = [
+        { objectID: 2, title: "Adulthood" },
+        { objectID: 5, title: "Childhood" },
+        { objectID: 9, title: "Youth" },
+      ];
+      // search endpoint returning objectIDs
+      metMock.onGet("/search?q=klint").reply(200, mockSearchData);
+
+      // object endpoint returning object details
+      mockObjectData.forEach((object) => {
+        metMock.onGet(`/objects/${object.objectID}`).reply(200, object);
+      });
+
+      const result = await fetchArtworksMet("klint");
+
+      expect(result).toEqual(mockObjectData);
+    });
+    it("handles network errors in Met search with 500 status response and error message", async () => {
+      metMock.onGet("/search?q=klint").reply(500);
+
+      await expect(fetchArtworksMet("klint")).rejects.toThrow(
+        "The Met Museum of Art API request failed"
+      );
+    });
+  });
+  describe("GET: combined API functions", () => {
+    afterEach(() => {
+      vaMock.reset();
+      metMock.reset();
+    });
+    const mockCombinedArtworksArrayData = [
+      {
+        id: "123",
+        title: "Blue Nude",
+        artist: "Matisse",
+        image: "va-image-url.jpg",
+        source: "Victoria and Albert Museum",
+      },
+      {
+        id: "789",
+        title: "Vegetables",
+        artist: "Matisse",
+        image: "met-image-url.jpg",
+        source: "The Metropolitan Museum of Art",
+      },
+    ];
+    it("fetches combined artworks as an array  of artwork objects with the specified response structure", async () => {
+      vaMock.onGet("/search?q=matisse&page_size=10").reply(200, {
+        records: [
+          {
+            systemNumber: "123",
+            _primaryTitle: "Blue Nude",
+            _primaryMaker: "Matisse",
+            _images: { _primary_thumbnail: "va-image-url.jpg" },
+          },
+        ],
+      });
+
+      metMock.onGet("/search?q=matisse").reply(200, {
+        objectIDs: [789],
+      });
+
+      metMock.onGet(`/objects/789`).reply(200, {
+        objectID: 789,
+        title: "Vegetables",
+        artistDisplayName: "Matisse",
+        primaryImageSmall: "met-image-url.jpg",
+      });
+
+      const results = await fetchCombinedArtworks("matisse");
+      console.log(results);
+
+      expect(results).toEqual(mockCombinedArtworksArrayData);
+    });
   });
 });

--- a/api/api.ts
+++ b/api/api.ts
@@ -1,9 +1,9 @@
-import { handleAxiosError } from "@/utils/errorHandler";
+import { handleAxiosError } from "../utils/errorHandler";
 import axios from "axios";
 
 // V&A Museum API
 export const vaApi = axios.create({
-  baseURL: "https://api.vam.ac.uk/v2/objects/",
+  baseURL: "https://api.vam.ac.uk/v2/objects",
 });
 
 export function fetchArtworksVA(query: string) {
@@ -24,7 +24,7 @@ export function getVAImageURL(imageId: number, size: number) {
 // MET Museum of Art API
 
 export const metApi = axios.create({
-  baseURL: "https://collectionapi.metmuseum.org/public/collection/v1/",
+  baseURL: "https://collectionapi.metmuseum.org/public/collection/v1",
 });
 
 export async function fetchArtworksMet(query: string) {
@@ -33,17 +33,52 @@ export async function fetchArtworksMet(query: string) {
       data: { objectIDs },
     } = await metApi.get(`/search?q=${query}`);
 
-    if (objectIDs) {
+    if (objectIDs.length > 0) {
       const objectDetails = await Promise.all(
         objectIDs.slice(0, 10).map(async (id: number) => {
           const { data } = await metApi.get(`/objects/${id}`);
           return data;
         })
       );
-
       return objectDetails;
     }
   } catch (err) {
     throw handleAxiosError(err, "MET");
+  }
+}
+
+// combined artworks
+
+export async function fetchCombinedArtworks(query: string) {
+  try {
+    const [vaData, metData] = await Promise.all([
+      fetchArtworksVA(query).catch((err) => {
+        return null;
+      }),
+      fetchArtworksMet(query).catch((err) => {
+        return null;
+      }),
+    ]);
+
+    const vaArtworks =
+      vaData?.records?.map((item: any) => ({
+        id: item.systemNumber,
+        title: item._primaryTitle || "Untitled",
+        artist: item._primaryMaker || "Unattributed or unknown",
+        image: item._images._primary_thumbnail || null,
+        source: "Victoria and Albert Museum",
+      })) || [];
+
+    const metArtworks =
+      metData?.map((item: any) => ({
+        id: item.objectID.toString(),
+        title: item.title || "Untitled",
+        artist: item.artistDisplayName || "Unattributed or unknown",
+        image: item.primaryImageSmall || null,
+        source: "The Metropolitan Museum of Art",
+      })) || [];
+    return [...vaArtworks, ...metArtworks];
+  } catch (err) {
+    throw handleAxiosError(err, "default");
   }
 }

--- a/components/widget/Search.tsx
+++ b/components/widget/Search.tsx
@@ -9,7 +9,7 @@ import {
   Keyboard,
   Dimensions,
 } from "react-native";
-import { searchVARecordsQuery } from "@/api/api";
+import { useArtworksQuery } from "../hooks/useArtworks";
 import { useState } from "react";
 
 const { width } = Dimensions.get("window");
@@ -17,7 +17,7 @@ const { width } = Dimensions.get("window");
 export default function Search() {
   const [searchQuery, setSearchQuery] = useState("");
   const [submittedQuery, setSubmittedQuery] = useState("");
-  const { data, isLoading, error } = searchVARecordsQuery(submittedQuery);
+  const { data, isLoading, error } = useArtworksQuery(submittedQuery);
 
   if (isLoading) return <ActivityIndicator size="large" color={"#00ff00"} />;
   if (error) return <Text style={styles.text}>Error: {error.message}</Text>;


### PR DESCRIPTION
- Adds test for fetchCombinedArtworks which uses both V&A and Met API functions, combines the data and returns it in a consistent format
- Implements operational fetchCombinedArtworks function which standardises the data from both museum API functions ready for easier rendering in UI components